### PR TITLE
Refactor to remove netns.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,9 +60,6 @@ pub enum Error {
     #[error("Failed to close netns,{0}")]
     CloseNsError(nix::Error),
 
-    #[error("Can not remove netns {0}, {1}")]
-    RemoveNsError(std::path::PathBuf, std::io::Error),
-
     #[error("Failed to mount {0}, {1}")]
     MountError(String, nix::Error),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //!}).unwrap();
 //!
 //!// removes netns.
-//!ns.umount().unwrap();
+//!ns.remove().unwrap();
 //!```
 //! To get a Netns that already exists, you can use the [`NetNs::get`] series of functions.
 //!```no_run


### PR DESCRIPTION
When netns is deleted, the NetNs instance will no longer be available
and we should use the `self` argument in the remove function in order
to consume the NetNs instance.                                       
                                                                     
Signed-off-by: wllenyj <wllenyj@linux.alibaba.com>                   